### PR TITLE
feat: add multi-page website structure

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,138 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+:root {
+  --primary:#0ea5e9;
+  --dark:#0f172a;
+  --light:#ffffff;
+  --text:#1f2937;
+}
+
+*{margin:0;padding:0;box-sizing:border-box;}
+body{
+  font-family:'Inter',sans-serif;
+  line-height:1.6;
+  color:var(--text);
+  background:var(--light);
+}
+
+.container{
+  width:90%;
+  max-width:1200px;
+  margin:0 auto;
+}
+
+header{
+  background:var(--light);
+  box-shadow:0 2px 4px rgba(0,0,0,0.05);
+  position:sticky;
+  top:0;
+  z-index:100;
+}
+.navbar{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:1rem 0;
+}
+.logo{
+  font-weight:700;
+  font-size:1.2rem;
+  color:var(--dark);
+  text-decoration:none;
+}
+.nav-links{
+  display:flex;
+  gap:1rem;
+}
+.nav-links a{
+  padding:.5rem .75rem;
+  border-radius:4px;
+  color:var(--dark);
+  text-decoration:none;
+}
+.nav-links a.active,
+.nav-links a:hover{
+  background:var(--primary);
+  color:#fff;
+}
+
+.hero{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:2rem;
+  padding:4rem 0;
+}
+.hero-content{flex:1;}
+.hero h1{font-size:2.5rem;margin-bottom:1rem;}
+.hero p{margin-bottom:1.5rem;color:#555;}
+.btn{
+  display:inline-block;
+  padding:.75rem 1.5rem;
+  border-radius:4px;
+  text-decoration:none;
+}
+.btn-primary{background:var(--primary);color:#fff;}
+.btn-primary:hover{opacity:.9;}
+.btn-secondary{border:2px solid var(--primary);color:var(--primary);}
+.btn-secondary:hover{background:var(--primary);color:#fff;}
+.hero img{max-width:100%;height:auto;border-radius:8px;}
+
+.section{padding:4rem 0;}
+.about{background:#f1f5f9;}
+.section h2{font-size:2rem;margin-bottom:1rem;}
+.section p{margin-bottom:1rem;color:#555;}
+
+.grid{
+  display:grid;
+  gap:2rem;
+}
+.services-grid{grid-template-columns:repeat(auto-fit,minmax(250px,1fr));}
+.service-card{
+  padding:1.5rem;
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  border-radius:8px;
+  text-align:center;
+}
+.service-card img{width:60px;height:60px;margin-bottom:1rem;}
+
+.portfolio-grid{grid-template-columns:repeat(auto-fit,minmax(250px,1fr));}
+.portfolio-item{background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:1rem;}
+.portfolio-item img{width:100%;height:auto;border-radius:8px;margin-bottom:.5rem;}
+
+.testimonial-card{
+  padding:1.5rem;
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  border-radius:8px;
+}
+.stars{color:#fbbf24;font-size:1.2rem;}
+
+form{max-width:600px;margin:0 auto;}
+.form-group{display:flex;flex-direction:column;margin-bottom:1rem;}
+.form-group label{margin-bottom:.5rem;}
+.form-group input,
+.form-group textarea{
+  padding:.5rem;
+  border:1px solid #cbd5e1;
+  border-radius:4px;
+}
+.form-group textarea{min-height:120px;resize:vertical;}
+
+footer{
+  background:var(--dark);
+  color:#fff;
+  padding:2rem 0;
+  margin-top:4rem;
+}
+footer .footer-content{display:flex;justify-content:space-between;flex-wrap:wrap;gap:2rem;}
+footer a{color:#fff;text-decoration:none;}
+footer ul{list-style:none;display:flex;gap:1rem;padding:0;}
+
+@media(max-width:768px){
+  .hero{flex-direction:column;text-align:center;}
+  .nav-links{flex-wrap:wrap;justify-content:center;}
+  footer .footer-content{flex-direction:column;align-items:center;}
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
+
+  const form = document.getElementById('quote-form');
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      if (!form.checkValidity()) {
+        // allow browser to display validation errors
+        return;
+      }
+      e.preventDefault();
+      alert('Thank you! We\'ll be in touch shortly.');
+      form.reset();
+    });
+  }
+});

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>UGC Pro Ads | High-Converting UGC</title>
-  <meta name="description" content="UGC Pro Ads produces user-generated content that builds trust and drives sales. Learn about our mission and team." />
+  <title>Portfolio | UGC Pro Ads</title>
+  <meta name="description" content="View sample projects produced by UGC Pro Ads." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -12,9 +12,9 @@
     <div class="container navbar">
       <a href="index.html" class="logo">UGC Pro Ads</a>
       <nav class="nav-links">
-        <a href="index.html" class="active">Home</a>
+        <a href="index.html">Home</a>
         <a href="services.html">Services</a>
-        <a href="portfolio.html">Portfolio</a>
+        <a href="portfolio.html" class="active">Portfolio</a>
         <a href="testimonials.html">Testimonials</a>
         <a href="quote.html">Get a Quote</a>
       </nav>
@@ -22,21 +22,28 @@
   </header>
 
   <main>
-    <section class="hero container">
-      <div class="hero-content">
-        <h1>UGC That Converts</h1>
-        <p>UGC Pro Ads helps brands connect with customers through authentic creator content. We script, shoot, and edit performance-driven ads.</p>
-        <a class="btn btn-primary" href="quote.html">Get a Quote</a>
-        <a class="btn btn-secondary" href="#about">Learn More</a>
-      </div>
-      <img src="https://via.placeholder.com/500x300" alt="Creators producing content" />
-    </section>
-
-    <section id="about" class="section about">
-      <div class="container">
-        <h2>About Us</h2>
-        <p>Founded by performance marketers, UGC Pro Ads specializes in user-generated content that feels real and converts browsers into buyers.</p>
-        <p>Our mission is to make high-quality creative accessible to brands of all sizes by working with a vetted network of creators and data-driven scripts.</p>
+    <section class="section container">
+      <h1>Portfolio</h1>
+      <p>A selection of recent projects and campaigns.</p>
+      <div class="grid portfolio-grid">
+        <div class="portfolio-item">
+          <img src="https://via.placeholder.com/400x250" alt="Project 1" />
+          <h3>App Launch Campaign</h3>
+          <p>Three creator videos drove 5x ROAS during launch week.</p>
+          <a href="#">View Details</a>
+        </div>
+        <div class="portfolio-item">
+          <img src="https://via.placeholder.com/400x250" alt="Project 2" />
+          <h3>DTC Product Demo</h3>
+          <p>Product demonstrations that boosted landing page conversions.</p>
+          <a href="#">View Details</a>
+        </div>
+        <div class="portfolio-item">
+          <img src="https://via.placeholder.com/400x250" alt="Project 3" />
+          <h3>Seasonal Promotion</h3>
+          <p>Short-form ads featuring holiday messaging and limited offers.</p>
+          <a href="#">View Details</a>
+        </div>
       </div>
     </section>
   </main>

--- a/quote.html
+++ b/quote.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>UGC Pro Ads | High-Converting UGC</title>
-  <meta name="description" content="UGC Pro Ads produces user-generated content that builds trust and drives sales. Learn about our mission and team." />
+  <title>Get a Quote | UGC Pro Ads</title>
+  <meta name="description" content="Request a project quote from UGC Pro Ads." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -12,32 +12,38 @@
     <div class="container navbar">
       <a href="index.html" class="logo">UGC Pro Ads</a>
       <nav class="nav-links">
-        <a href="index.html" class="active">Home</a>
+        <a href="index.html">Home</a>
         <a href="services.html">Services</a>
         <a href="portfolio.html">Portfolio</a>
         <a href="testimonials.html">Testimonials</a>
-        <a href="quote.html">Get a Quote</a>
+        <a href="quote.html" class="active">Get a Quote</a>
       </nav>
     </div>
   </header>
 
   <main>
-    <section class="hero container">
-      <div class="hero-content">
-        <h1>UGC That Converts</h1>
-        <p>UGC Pro Ads helps brands connect with customers through authentic creator content. We script, shoot, and edit performance-driven ads.</p>
-        <a class="btn btn-primary" href="quote.html">Get a Quote</a>
-        <a class="btn btn-secondary" href="#about">Learn More</a>
-      </div>
-      <img src="https://via.placeholder.com/500x300" alt="Creators producing content" />
-    </section>
-
-    <section id="about" class="section about">
-      <div class="container">
-        <h2>About Us</h2>
-        <p>Founded by performance marketers, UGC Pro Ads specializes in user-generated content that feels real and converts browsers into buyers.</p>
-        <p>Our mission is to make high-quality creative accessible to brands of all sizes by working with a vetted network of creators and data-driven scripts.</p>
-      </div>
+    <section class="section container">
+      <h1>Get a Quote</h1>
+      <p>Tell us about your project and we'll respond within 1–2 business days.</p>
+      <form id="quote-form" novalidate>
+        <div class="form-group">
+          <label for="name">Name*</label>
+          <input type="text" id="name" required />
+        </div>
+        <div class="form-group">
+          <label for="email">Email*</label>
+          <input type="email" id="email" required />
+        </div>
+        <div class="form-group">
+          <label for="details">Project Details*</label>
+          <textarea id="details" required></textarea>
+        </div>
+        <div class="form-group">
+          <label for="budget">Budget</label>
+          <input type="text" id="budget" />
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+      </form>
     </section>
   </main>
 

--- a/services.html
+++ b/services.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>UGC Pro Ads | High-Converting UGC</title>
-  <meta name="description" content="UGC Pro Ads produces user-generated content that builds trust and drives sales. Learn about our mission and team." />
+  <title>Services | UGC Pro Ads</title>
+  <meta name="description" content="Discover the UGC production and strategy services offered by UGC Pro Ads." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -12,8 +12,8 @@
     <div class="container navbar">
       <a href="index.html" class="logo">UGC Pro Ads</a>
       <nav class="nav-links">
-        <a href="index.html" class="active">Home</a>
-        <a href="services.html">Services</a>
+        <a href="index.html">Home</a>
+        <a href="services.html" class="active">Services</a>
         <a href="portfolio.html">Portfolio</a>
         <a href="testimonials.html">Testimonials</a>
         <a href="quote.html">Get a Quote</a>
@@ -22,21 +22,25 @@
   </header>
 
   <main>
-    <section class="hero container">
-      <div class="hero-content">
-        <h1>UGC That Converts</h1>
-        <p>UGC Pro Ads helps brands connect with customers through authentic creator content. We script, shoot, and edit performance-driven ads.</p>
-        <a class="btn btn-primary" href="quote.html">Get a Quote</a>
-        <a class="btn btn-secondary" href="#about">Learn More</a>
-      </div>
-      <img src="https://via.placeholder.com/500x300" alt="Creators producing content" />
-    </section>
-
-    <section id="about" class="section about">
-      <div class="container">
-        <h2>About Us</h2>
-        <p>Founded by performance marketers, UGC Pro Ads specializes in user-generated content that feels real and converts browsers into buyers.</p>
-        <p>Our mission is to make high-quality creative accessible to brands of all sizes by working with a vetted network of creators and data-driven scripts.</p>
+    <section class="section container">
+      <h1>Services</h1>
+      <p>We provide end-to-end UGC production so you can focus on growing your brand.</p>
+      <div class="grid services-grid">
+        <div class="service-card">
+          <img src="https://via.placeholder.com/80" alt="Script icon" />
+          <h3>Concept & Script</h3>
+          <p>Creative hooks and persuasive scripts crafted for your audience.</p>
+        </div>
+        <div class="service-card">
+          <img src="https://via.placeholder.com/80" alt="Camera icon" />
+          <h3>UGC Production</h3>
+          <p>Vetted creators shoot authentic content tailored to your brand.</p>
+        </div>
+        <div class="service-card">
+          <img src="https://via.placeholder.com/80" alt="Editing icon" />
+          <h3>Editing & Iteration</h3>
+          <p>Fast edits, captions, and multiple variations for testing.</p>
+        </div>
       </div>
     </section>
   </main>

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>UGC Pro Ads | High-Converting UGC</title>
-  <meta name="description" content="UGC Pro Ads produces user-generated content that builds trust and drives sales. Learn about our mission and team." />
+  <title>Testimonials | UGC Pro Ads</title>
+  <meta name="description" content="Hear from brands who trust UGC Pro Ads for their creator content." />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -12,31 +12,35 @@
     <div class="container navbar">
       <a href="index.html" class="logo">UGC Pro Ads</a>
       <nav class="nav-links">
-        <a href="index.html" class="active">Home</a>
+        <a href="index.html">Home</a>
         <a href="services.html">Services</a>
         <a href="portfolio.html">Portfolio</a>
-        <a href="testimonials.html">Testimonials</a>
+        <a href="testimonials.html" class="active">Testimonials</a>
         <a href="quote.html">Get a Quote</a>
       </nav>
     </div>
   </header>
 
   <main>
-    <section class="hero container">
-      <div class="hero-content">
-        <h1>UGC That Converts</h1>
-        <p>UGC Pro Ads helps brands connect with customers through authentic creator content. We script, shoot, and edit performance-driven ads.</p>
-        <a class="btn btn-primary" href="quote.html">Get a Quote</a>
-        <a class="btn btn-secondary" href="#about">Learn More</a>
-      </div>
-      <img src="https://via.placeholder.com/500x300" alt="Creators producing content" />
-    </section>
-
-    <section id="about" class="section about">
-      <div class="container">
-        <h2>About Us</h2>
-        <p>Founded by performance marketers, UGC Pro Ads specializes in user-generated content that feels real and converts browsers into buyers.</p>
-        <p>Our mission is to make high-quality creative accessible to brands of all sizes by working with a vetted network of creators and data-driven scripts.</p>
+    <section class="section container">
+      <h1>Testimonials</h1>
+      <p>Brands and marketers share their experiences working with us.</p>
+      <div class="grid services-grid">
+        <div class="testimonial-card">
+          <p>"UGC Pro Ads delivered three killer videos that doubled our trial sign-ups."</p>
+          <p class="stars">★★★★★</p>
+          <p><strong>Jane D., SaaS Founder</strong></p>
+        </div>
+        <div class="testimonial-card">
+          <p>"Their scripts and creative direction are always on point."</p>
+          <p class="stars">★★★★☆</p>
+          <p><strong>Mark T., Marketing Lead</strong></p>
+        </div>
+        <div class="testimonial-card">
+          <p>"Fast turnaround and easy communication from start to finish."</p>
+          <p class="stars">★★★★★</p>
+          <p><strong>Anonymous</strong></p>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- rebuild home page around hero intro and about section
- add services, portfolio, testimonials and quote pages with shared header/footer
- include responsive styling and client-side quote form handling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af70a9e224833283bfe779a692ea71