### PR TITLE
Enable native form validation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (form) {
     form.addEventListener('submit', (e) => {
       if (!form.checkValidity()) {
-        // allow browser to display validation errors
+        form.reportValidity();
+        e.preventDefault();
         return;
       }
       e.preventDefault();

--- a/quote.html
+++ b/quote.html
@@ -21,29 +21,29 @@
     </div>
   </header>
 
-  <main>
-    <section class="section container">
-      <h1>Get a Quote</h1>
-      <p>Tell us about your project and we'll respond within 1–2 business days.</p>
-      <form id="quote-form" novalidate>
-        <div class="form-group">
-          <label for="name">Name*</label>
-          <input type="text" id="name" required />
-        </div>
-        <div class="form-group">
-          <label for="email">Email*</label>
-          <input type="email" id="email" required />
-        </div>
-        <div class="form-group">
-          <label for="details">Project Details*</label>
-          <textarea id="details" required></textarea>
-        </div>
-        <div class="form-group">
-          <label for="budget">Budget</label>
-          <input type="text" id="budget" />
-        </div>
-        <button type="submit" class="btn btn-primary">Submit</button>
-      </form>
+    <main>
+      <section class="section container">
+        <h1>Get a Quote</h1>
+        <p>Tell us about your project and we'll respond within 1–2 business days.</p>
+        <form id="quote-form">
+          <div class="form-group">
+            <label for="name">Name*</label>
+            <input type="text" id="name" required />
+          </div>
+          <div class="form-group">
+            <label for="email">Email*</label>
+            <input type="email" id="email" required />
+          </div>
+          <div class="form-group">
+            <label for="details">Project Details*</label>
+            <textarea id="details" required></textarea>
+          </div>
+          <div class="form-group">
+            <label for="budget">Budget</label>
+            <input type="text" id="budget" />
+          </div>
+          <button type="submit" class="btn btn-primary">Submit</button>
+        </form>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- remove `novalidate` attribute to use built-in browser validation on the quote form
- ensure invalid submissions call `reportValidity()` and prevent submission

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af79d75d6083329ff4dfd8f1dbef3e